### PR TITLE
oop module interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,22 +33,22 @@ Having installed the package and/or added it as a dependency to your project, yo
 
 var decodedAuth = require('decoded-express-auth'); // Import the middleware library
 
-// inititalise decodedAuth
-decodedAuth.init(app); // Pass in your express app instance here
+// inititalise an instance of decoded auth
+var auth = new decodedAuth(app); // Pass in your express app instance here
 ```
 
-Use the `requiresLogin` middleware provided by this app whenever you have one or more URL routes you want to be protected behind Auth0 authentication. Attempting to access any of the routes using this middleware will redirect the user to Auth0 to login first before allowing them to continue:
+Use the `requiresLogin` middleware method of your auth instance whenever you have one or more URL routes you want to be protected behind Auth0 authentication. Attempting to access any of the routes using this middleware will redirect the user to Auth0 to login first before allowing them to continue:
 
 ```js
 // Any URL route defined after this point will require authentication
-app.use(decodedAuth.requiresLogin);
+app.use(auth.requiresLogin);
 ```
 
 OR:
 
 ```js
 // Here it is used as a per-route middleware to protect only this URL route
-app.get('/my-fab-route', decodedAuth.requiresLogin, function(req,res) {
+app.get('/my-fab-route', auth.requiresLogin, function(req,res) {
   res.send('My route rocks! 🐸 💜');
 })
 ```
@@ -71,7 +71,7 @@ If you **really need to**, you can set these values via the options argument whe
 
 ### Options Object
 
-When initialising the middleware, you can optionally provide a second argument to the `init()` function - this should be an object. This can include options that override some configuration parameters of the middleware.
+When initialising the middleware, you can optionally provide a second argument to the `decodedAuth()` constructor - this should be an object. This can include options that override some configuration parameters of the middleware.
 
 The options are:
 

--- a/auth.js
+++ b/auth.js
@@ -18,9 +18,6 @@ var merge = require('merge');
 // global module default config object
 var OPTIONS = {
   auth0: {
-    domain: process.env.AUTH0_DOMAIN,
-    clientID: process.env.AUTH0_CLIENT_ID,
-    clientSecret: process.env.AUTH0_CLIENT_SECRET,
     callbackURL: '/auth/callback'
   },
   cookieSecret: uuid.v4(),
@@ -59,10 +56,42 @@ var authCallbackHandler = function (req, res) {
 }
 
 /*
+ * This is called by init() and is used to load Auth0 config variables from
+ * environment variables. You can also call it yourself if you want.
+ * By default, this doesn't override variables that already exit, but you
+ * can optionally tell it to override all variables with the environment ones
+ * if you want, with the sole function argument.
+ */
+exports.reloadConfig = function(override) {
+  if (override) {
+    OPTIONS.auth0 = merge(
+      OPTIONS.auth0,
+      {
+        domain: process.env.AUTH0_DOMAIN,
+        clientID: process.env.AUTH0_CLIENT_ID,
+        clientSecret: process.env.AUTH0_CLIENT_SECRET
+      }
+    );
+  } else {
+    if (!OPTIONS.auth0.domain) {
+      OPTIONS.auth0.domain = process.env.AUTH0_DOMAIN;
+    }
+    if (!OPTIONS.auth0.clientID) {
+      OPTIONS.auth0.clientID = process.env.AUTH0_CLIENT_ID;
+    }
+    if (!OPTIONS.auth0.clientSecret) {
+      OPTIONS.auth0.clientSecret = process.env.AUTH0_CLIENT_SECRET;
+    }
+  }
+}
+
+/*
  * Call this once with your express app instance as the first argument and an
  * options object as the second. This will setup and initialise the middleware.
  */
 exports.init = function (app, options) {
+  // reload options from environment variables
+  module.exports.reloadConfig(false);
   // override any options that were specified
   if (options) {
     OPTIONS = merge.recursive(OPTIONS, options);

--- a/auth.js
+++ b/auth.js
@@ -15,17 +15,67 @@ var uuid = require('node-uuid');
 // for overriding options object
 var merge = require('merge');
 
-// global module default config object
-var OPTIONS = {
-  auth0: {
-    callbackURL: '/auth/callback'
-  },
-  cookieSecret: uuid.v4(),
-  successRedirect: '/',
-  failureRedirect: '/',
-  serializeUser: null,
-  deserializeUser: null
-};
+/*
+ * Main prototype constructor
+ * Call this once with your express app instance as the first argument and an
+ * options object as the second. This will setup and initialise one instance of
+ * the middleware.
+ */
+module.exports = function(app, options) {
+  // define private variables
+  var _options = {
+    auth0: {
+      callbackURL: '/auth/callback'
+    },
+    cookieSecret: uuid.v4(),
+    successRedirect: '/',
+    failureRedirect: '/',
+    serializeUser: null,
+    deserializeUser: null
+  };
+
+  // reload options from environment variables
+  reloadConfig(false);
+
+  // override any options that were specified
+  if (options) {
+    _options = merge.recursive(_options, options);
+  }
+
+  // public methods
+  return {
+    /*
+     * This is called by module constructor and is used to load Auth0 config variables
+     * from environment variables. You can also call it yourself if you want.
+     * By default, this doesn't override variables that already exit, but you
+     * can optionally tell it to override all variables with the environment ones
+     * if you want, with the sole function argument.
+     */
+    reloadConfig: function(override) {
+      if (override) {
+        _options.auth0 = merge(
+          _options.auth0,
+          {
+            domain: process.env.AUTH0_DOMAIN,
+            clientID: process.env.AUTH0_CLIENT_ID,
+            clientSecret: process.env.AUTH0_CLIENT_SECRET
+          }
+        );
+      } else {
+        if (!_options.auth0.domain) {
+          _options.auth0.domain = process.env.AUTH0_DOMAIN;
+        }
+        if (!_options.auth0.clientID) {
+          _options.auth0.clientID = process.env.AUTH0_CLIENT_ID;
+        }
+        if (!_options.auth0.clientSecret) {
+          _options.auth0.clientSecret = process.env.AUTH0_CLIENT_SECRET;
+        }
+      }
+    },
+    ...
+  };
+}
 
 // passportjs verify callback for the Auth0Strategy
 var verifyCallback = function (
@@ -53,36 +103,6 @@ var authCallbackHandler = function (req, res) {
     throw new Error('user null');
   }
   res.redirect(OPTIONS.successRedirect);
-}
-
-/*
- * This is called by init() and is used to load Auth0 config variables from
- * environment variables. You can also call it yourself if you want.
- * By default, this doesn't override variables that already exit, but you
- * can optionally tell it to override all variables with the environment ones
- * if you want, with the sole function argument.
- */
-exports.reloadConfig = function(override) {
-  if (override) {
-    OPTIONS.auth0 = merge(
-      OPTIONS.auth0,
-      {
-        domain: process.env.AUTH0_DOMAIN,
-        clientID: process.env.AUTH0_CLIENT_ID,
-        clientSecret: process.env.AUTH0_CLIENT_SECRET
-      }
-    );
-  } else {
-    if (!OPTIONS.auth0.domain) {
-      OPTIONS.auth0.domain = process.env.AUTH0_DOMAIN;
-    }
-    if (!OPTIONS.auth0.clientID) {
-      OPTIONS.auth0.clientID = process.env.AUTH0_CLIENT_ID;
-    }
-    if (!OPTIONS.auth0.clientSecret) {
-      OPTIONS.auth0.clientSecret = process.env.AUTH0_CLIENT_SECRET;
-    }
-  }
 }
 
 /*

--- a/auth.js
+++ b/auth.js
@@ -127,7 +127,7 @@ module.exports = function(app, options) {
   // create Auth0 failure route if requested
   if (_options.useDefaultFailureRoute) {
     app.get(
-      _options.auth0.failureRedirect,
+      _options.failureRedirect,
       function (req, res) {
         res.sendStatus(403);
       }

--- a/auth.js
+++ b/auth.js
@@ -37,6 +37,20 @@ module.exports = function(app, options) {
   // end private variables
 
   // begin private methods
+  /*
+   * This is called by module constructor and is used to load Auth0 config variables
+   * from environment variables.
+   */
+  var loadConfig = function () {
+    _options.auth0 = merge(
+      _options.auth0,
+      {
+        domain: process.env.AUTH0_DOMAIN,
+        clientID: process.env.AUTH0_CLIENT_ID,
+        clientSecret: process.env.AUTH0_CLIENT_SECRET
+      }
+    );
+  };
   // passportjs verify callback for the Auth0Strategy
   var verifyCallback = function (
     accessToken, refreshToken, extraParams, profile, done
@@ -64,35 +78,6 @@ module.exports = function(app, options) {
   // end private methods
 
   // begin public methods
-  /*
-   * This is called by module constructor and is used to load Auth0 config variables
-   * from environment variables. You can also call it yourself if you want.
-   * By default, this doesn't override variables that already exit, but you
-   * can optionally tell it to override all variables with the environment ones
-   * if you want, with the sole function argument.
-   */
-  this.reloadConfig = function (override) {
-    if (override) {
-      _options.auth0 = merge(
-        _options.auth0,
-        {
-          domain: process.env.AUTH0_DOMAIN,
-          clientID: process.env.AUTH0_CLIENT_ID,
-          clientSecret: process.env.AUTH0_CLIENT_SECRET
-        }
-      );
-    } else {
-      if (!_options.auth0.domain) {
-        _options.auth0.domain = process.env.AUTH0_DOMAIN;
-      }
-      if (!_options.auth0.clientID) {
-        _options.auth0.clientID = process.env.AUTH0_CLIENT_ID;
-      }
-      if (!_options.auth0.clientSecret) {
-        _options.auth0.clientSecret = process.env.AUTH0_CLIENT_SECRET;
-      }
-    }
-  };
   // Use this middleware to protect one or more routes from access without auth
   this.requiresLogin = function (req, res, next) {
     if (!req.isAuthenticated()) {
@@ -103,8 +88,8 @@ module.exports = function(app, options) {
   // end public methods
 
   // begin constructor function proper
-  // reload options from environment variables
-  this.reloadConfig(false);
+  // load options from environment variables
+  loadConfig();
   // override any options that were specified
   if (options) {
     _options = merge.recursive(_options, options);

--- a/auth.js
+++ b/auth.js
@@ -30,8 +30,10 @@ module.exports = function(app, options) {
     cookieSecret: uuid.v4(),
     successRedirect: '/',
     failureRedirect: '/',
-    serializeUser: null,
-    deserializeUser: null
+    serializeUser: null,  // optional pointer to a callback function
+    deserializeUser: null, // as above
+    // if set to true, the library will automatically provide a failure route
+    useDefaultFailureRoute: true
   };
   var strategy;
   // end private variables
@@ -122,5 +124,14 @@ module.exports = function(app, options) {
     ),
     authCallbackHandler
   );
+  // create Auth0 failure route if requested
+  if (_options.useDefaultFailureRoute) {
+    app.get(
+      _options.auth0.failureRedirect,
+      function (req, res) {
+        res.send(403);
+      }
+    )
+  }
   // end constructor function proper
 };

--- a/auth.js
+++ b/auth.js
@@ -22,7 +22,7 @@ var merge = require('merge');
  * the middleware.
  */
 module.exports = function(app, options) {
-  // define private variables
+  // begin private variables
   var _options = {
     auth0: {
       callbackURL: '/auth/callback'
@@ -34,15 +34,80 @@ module.exports = function(app, options) {
     deserializeUser: null
   };
   var strategy;
+  // end private variables
 
+  // begin private methods
+  // passportjs verify callback for the Auth0Strategy
+  var verifyCallback = function (
+    accessToken, refreshToken, extraParams, profile, done
+  ) {
+    // accessToken is the token to call Auth0 API (not needed in the most cases)
+    // extraParams.id_token has the JSON Web Token
+    // profile has all the information from the user
+    return done(null, profile);
+  };
+  // passportjs default user serialisation/deserialisation functions
+  // This is not a best practice, but we want to keep things simple for now
+  var serializeUser = function (user, done) {
+    done(null, user);
+  };
+  var deserializeUser = function (user, done) {
+    done(null, user);
+  };
+  // the route handler for the auth0 callback
+  var authCallbackHandler = function (req, res) {
+    if (!req.user) {
+      throw new Error('user null');
+    }
+    res.redirect(_options.successRedirect);
+  };
+  // end private methods
+
+  // begin public methods
+  /*
+   * This is called by module constructor and is used to load Auth0 config variables
+   * from environment variables. You can also call it yourself if you want.
+   * By default, this doesn't override variables that already exit, but you
+   * can optionally tell it to override all variables with the environment ones
+   * if you want, with the sole function argument.
+   */
+  this.reloadConfig = function (override) {
+    if (override) {
+      _options.auth0 = merge(
+        _options.auth0,
+        {
+          domain: process.env.AUTH0_DOMAIN,
+          clientID: process.env.AUTH0_CLIENT_ID,
+          clientSecret: process.env.AUTH0_CLIENT_SECRET
+        }
+      );
+    } else {
+      if (!_options.auth0.domain) {
+        _options.auth0.domain = process.env.AUTH0_DOMAIN;
+      }
+      if (!_options.auth0.clientID) {
+        _options.auth0.clientID = process.env.AUTH0_CLIENT_ID;
+      }
+      if (!_options.auth0.clientSecret) {
+        _options.auth0.clientSecret = process.env.AUTH0_CLIENT_SECRET;
+      }
+    }
+  };
+  this.requiresLogin = function (req, res, next) {
+    if (!req.isAuthenticated()) {
+      return res.redirect(_options.auth0.callbackURL);
+    }
+    next();
+  };
+  // end public methods
+
+  // begin constructor function proper
   // reload options from environment variables
-  reloadConfig(false);
-
+  this.reloadConfig(false);
   // override any options that were specified
   if (options) {
     _options = merge.recursive(_options, options);
   }
-
   // build auth0 passportjs strategy
   strategy = new Auth0Strategy(_options.auth0, verifyCallback);
   passport.use(strategy);
@@ -71,67 +136,5 @@ module.exports = function(app, options) {
     ),
     authCallbackHandler
   );
-
-  // public methods
-  return {
-    /*
-     * This is called by module constructor and is used to load Auth0 config variables
-     * from environment variables. You can also call it yourself if you want.
-     * By default, this doesn't override variables that already exit, but you
-     * can optionally tell it to override all variables with the environment ones
-     * if you want, with the sole function argument.
-     */
-    reloadConfig: function (override) {
-      if (override) {
-        _options.auth0 = merge(
-          _options.auth0,
-          {
-            domain: process.env.AUTH0_DOMAIN,
-            clientID: process.env.AUTH0_CLIENT_ID,
-            clientSecret: process.env.AUTH0_CLIENT_SECRET
-          }
-        );
-      } else {
-        if (!_options.auth0.domain) {
-          _options.auth0.domain = process.env.AUTH0_DOMAIN;
-        }
-        if (!_options.auth0.clientID) {
-          _options.auth0.clientID = process.env.AUTH0_CLIENT_ID;
-        }
-        if (!_options.auth0.clientSecret) {
-          _options.auth0.clientSecret = process.env.AUTH0_CLIENT_SECRET;
-        }
-      }
-    },
-    // passportjs verify callback for the Auth0Strategy
-    verifyCallback: function (
-      accessToken, refreshToken, extraParams, profile, done
-    ) {
-      // accessToken is the token to call Auth0 API (not needed in the most cases)
-      // extraParams.id_token has the JSON Web Token
-      // profile has all the information from the user
-      return done(null, profile);
-    },
-    // passportjs default user serialisation/deserialisation functions
-    // This is not a best practice, but we want to keep things simple for now
-    serializeUser: function (user, done) {
-      done(null, user);
-    },
-    deserializeUser: function (user, done) {
-      done(null, user);
-    },
-    // the route handler for the auth0 callback
-    authCallbackHandler: function (req, res) {
-      if (!req.user) {
-        throw new Error('user null');
-      }
-      res.redirect(OPTIONS.successRedirect);
-    },
-    requiresLogin: function (req, res, next) {
-      if (!req.isAuthenticated()) {
-        return res.redirect(OPTIONS.auth0.callbackURL);
-      }
-      next();
-    }
-  };
+  // end constructor function proper
 };

--- a/auth.js
+++ b/auth.js
@@ -129,7 +129,7 @@ module.exports = function(app, options) {
     app.get(
       _options.auth0.failureRedirect,
       function (req, res) {
-        res.send(403);
+        res.sendStatus(403);
       }
     )
   }

--- a/auth.js
+++ b/auth.js
@@ -93,6 +93,7 @@ module.exports = function(app, options) {
       }
     }
   };
+  // Use this middleware to protect one or more routes from access without auth
   this.requiresLogin = function (req, res, next) {
     if (!req.isAuthenticated()) {
       return res.redirect(_options.auth0.callbackURL);


### PR DESCRIPTION
This refactors the whole module to provide an object-oriented interface rather than a functional one.

I'm not sure what affect using two separate instances of decodedAuth on the same app 😃  (may not end well if the login callback URL is not changed), but it is good from an encapsulation point of view and also means two express apps can use two different auth0 connections (or two separate parts of one express app, using sub-apps).

Closes #5