### PR TITLE
Amend default failure route to be different to success route

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -29,7 +29,7 @@ module.exports = function(app, options) {
     },
     cookieSecret: uuid.v4(),
     successRedirect: '/',
-    failureRedirect: '/',
+    failureRedirect: '/auth/failed',
     serializeUser: null,  // optional pointer to a callback function
     deserializeUser: null, // as above
     // if set to true, the library will automatically provide a failure route

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decoded-express-auth",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Authentication middleware for Decoded's Express-based applications",
   "main": "auth.js",
   "scripts": {


### PR DESCRIPTION
Currently this is the same as the success route by default (causes confusing, hard-to-diagnose errors with a minimal setup).
